### PR TITLE
Fix: Alliance selector display now updates during waitForStart

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/DecodeTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/DecodeTeleOp.java
@@ -234,13 +234,16 @@ public class DecodeTeleOp extends NextFTCOpMode {
             selectedAlliance = RobotState.getAlliance();
             return;
         }
-        selectedAlliance = RobotState.getAlliance();
 
-        if (selectedAlliance==null && allianceSelector != null) {
+        // Always update alliance selector from vision and button presses
+        if (allianceSelector != null) {
             allianceSelector.updateFromVision(robot.vision);
             allianceSelector.applySelection(robot, robot.lighting);
             selectedAlliance = allianceSelector.getSelectedAlliance();
+        } else {
+            selectedAlliance = RobotState.getAlliance();
         }
+
         // DISABLED: Skip initial relocalization to allow Limelight MT2 to stabilize with new heading
         // User can manually relocalize by pressing A after START if needed
         // if (robot.vision.shouldUpdateOdometry() && robot.drive.forceRelocalizeFromVision()) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/DecodeTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/DecodeTeleOp.java
@@ -98,15 +98,17 @@ public class DecodeTeleOp extends NextFTCOpMode {
 
     @Override
     public void onWaitForStart() {
+        BindingManager.update();
+        if (allianceSelector != null) {
+            selectedAlliance = allianceSelector.updateDuringInit(robot.vision, robot, robot.lighting);
+        }
         telemetry.addData("Alliance", selectedAlliance.displayName());
         telemetry.addLine("D-pad Left/Right override, Down uses vision, Up returns to default");
         telemetry.addLine("Press START when ready");
         telemetry.addLine();
-        BindingManager.update();
         if (lightingInitController != null) {
             lightingInitController.updateDuringInit(gamepad1.dpad_up);
         }
-        syncVisionDuringInit();
         pushInitTelemetry();
 
     }
@@ -227,29 +229,6 @@ public class DecodeTeleOp extends NextFTCOpMode {
             telemetry.addData("Vision re-localize", "Press A to sync with Limelight");
         }
         telemetry.addLine();
-    }
-
-    private void syncVisionDuringInit() {
-        if (robot == null || robot.drive == null || robot.vision == null) {
-            selectedAlliance = RobotState.getAlliance();
-            return;
-        }
-
-        // Always update alliance selector from vision and button presses
-        if (allianceSelector != null) {
-            allianceSelector.updateFromVision(robot.vision);
-            allianceSelector.applySelection(robot, robot.lighting);
-            selectedAlliance = allianceSelector.getSelectedAlliance();
-        } else {
-            selectedAlliance = RobotState.getAlliance();
-        }
-
-        // DISABLED: Skip initial relocalization to allow Limelight MT2 to stabilize with new heading
-        // User can manually relocalize by pressing A after START if needed
-        // if (robot.vision.shouldUpdateOdometry() && robot.drive.forceRelocalizeFromVision()) {
-        //     robot.drive.visionRelocalizeStatus = "Pose synced from Limelight";
-        //     robot.drive.visionRelocalizeStatusMs = System.currentTimeMillis();
-        // }
     }
 
     private static final class LoopTiming {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/AllianceSelector.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/AllianceSelector.java
@@ -95,6 +95,35 @@ public final class AllianceSelector {
         }
     }
 
+    /**
+     * Convenience method for updating alliance selection during OpMode init (waitForStart loop).
+     * Combines vision updates and selection application into a single call.
+     *
+     * <p>This is the drop-in method for OpModes. Call this in your waitForStart loop to:
+     * <ul>
+     *   <li>Poll vision for AprilTag alliance detection</li>
+     *   <li>Process manual dpad overrides (requires BindingManager.update() to be called first)</li>
+     *   <li>Apply the selection to robot state and lighting</li>
+     * </ul>
+     *
+     * <p>Usage example in waitForStart:
+     * <pre>{@code
+     * BindingManager.update(); // Process button presses
+     * Alliance currentAlliance = allianceSelector.updateDuringInit(robot.vision, robot, robot.lighting);
+     * telemetry.addData("Alliance", currentAlliance.displayName());
+     * }</pre>
+     *
+     * @param vision Vision subsystem for AprilTag detection (can be null)
+     * @param robot Robot container to apply alliance selection (can be null)
+     * @param lighting Lighting subsystem to apply alliance colors (can be null)
+     * @return The currently selected alliance
+     */
+    public Alliance updateDuringInit(VisionSubsystemLimelight vision, Robot robot, LightingSubsystem lighting) {
+        updateFromVision(vision);
+        applySelection(robot, lighting);
+        return selectedAlliance;
+    }
+
     public void selectAllianceManually(Alliance alliance) {
         if (selectionLocked) {
             return;


### PR DESCRIPTION
The alliance selector was working internally (responding to dpad button
presses) but the display wasn't updating until START was pressed.

The issue was in syncVisionDuringInit():
- It only updated the selector if selectedAlliance==null
- But selectedAlliance is initialized to Alliance.UNKNOWN (not null)
- After updating the selector, it never read back the current selection

Now the method:
- Always updates the alliance selector from vision and button presses
- Always reads back the selected alliance for display
- Properly shows alliance changes in real-time during init

This fixes the issue where teams couldn't see their alliance selection
updating when no auto handoff occurred.