### PR TITLE
Disable automatic vision relocalization with MT1

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Robot.java
@@ -31,8 +31,11 @@ public class Robot {
          * - Manual relocalization (A button) is still available when needed
          * - Once MT2 is working (2-3" accuracy, multi-tag fusion), re-enable this
          */
-        public static boolean enableAutoRelocalization = false;
+        public boolean enableAutoRelocalization = false;
     }
+
+    public static VisionConfig visionConfig = new VisionConfig();
+
     public final DriveSubsystem drive;
     public final LauncherSubsystem launcher;
     public final IntakeSubsystem intake;
@@ -75,7 +78,7 @@ public class Robot {
 
     public void initializeForTeleOp() {
         // Use configurable flag for vision relocalization (disabled by default with MT1)
-        configureInitialization(true, VisionConfig.enableAutoRelocalization);
+        configureInitialization(true, visionConfig.enableAutoRelocalization);
     }
 
     private void configureInitialization(boolean enableTeleOpControl, boolean enableVisionRelocalization) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Robot.java
@@ -15,27 +15,7 @@ import org.firstinspires.ftc.teamcode.util.Alliance;
 import org.firstinspires.ftc.teamcode.util.RobotState;
 import org.firstinspires.ftc.teamcode.telemetry.TelemetryService;
 
-@Configurable
 public class Robot {
-
-    @Configurable
-    public static class RelocalizationConfig {
-        /**
-         * Enable automatic vision relocalization during aiming in TeleOp.
-         *
-         * IMPORTANT: Currently using MegaTag1 (MT1) which is less reliable than MT2.
-         * MT1 provides single-tag poses with 4-8" accuracy and can be noisy/jumpy.
-         *
-         * Recommendation: Keep DISABLED until MegaTag2 (MT2) is fixed.
-         * - MT1 relocalization can introduce more error than odometry drift
-         * - Manual relocalization (A button) is still available when needed
-         * - Once MT2 is working (2-3" accuracy, multi-tag fusion), re-enable this
-         */
-        public boolean enableRelocalizationDuringAiming = false;
-    }
-
-    public static RelocalizationConfig relocalizationConfig = new RelocalizationConfig();
-
     public final DriveSubsystem drive;
     public final LauncherSubsystem launcher;
     public final IntakeSubsystem intake;
@@ -78,7 +58,7 @@ public class Robot {
 
     public void initializeForTeleOp() {
         // Use configurable flag for vision relocalization (disabled by default with MT1)
-        configureInitialization(true, relocalizationConfig.enableRelocalizationDuringAiming);
+        configureInitialization(true, DriveSubsystem.visionRelocalizationConfig.enableDuringAiming);
     }
 
     private void configureInitialization(boolean enableTeleOpControl, boolean enableVisionRelocalization) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Robot.java
@@ -49,27 +49,36 @@ public class Robot {
     }
 
     public void initialize() {
-        initializeForTeleOp();
-    }
-
-    public void initializeForAuto() {
-        configureInitialization(false, false);
-    }
-
-    public void initializeForTeleOp() {
-        // Use configurable flag for vision relocalization (disabled by default with MT1)
-        configureInitialization(true, DriveSubsystem.visionRelocalizationConfig.enableDuringAiming);
-    }
-
-    private void configureInitialization(boolean enableTeleOpControl, boolean enableVisionRelocalization) {
-        drive.setTeleOpControlEnabled(enableTeleOpControl);
-        drive.setVisionRelocalizationEnabled(enableVisionRelocalization);
+        drive.setTeleOpControlEnabled(true);
         vision.initialize();
         drive.initialize();
         launcher.initialize();
         lighting.initialize();
         intake.initialize();
 
+        // Wire lighting to receive lane color updates from intake
+        intake.addLaneColorListener(lighting);
+    }
+
+    public void initializeForAuto() {
+        drive.setTeleOpControlEnabled(false);
+        vision.initialize();
+        drive.initialize();
+        launcher.initialize();
+        lighting.initialize();
+        intake.initialize();
+
+        // Wire lighting to receive lane color updates from intake
+        intake.addLaneColorListener(lighting);
+    }
+
+    public void initializeForTeleOp() {
+        drive.setTeleOpControlEnabled(true);
+        vision.initialize();
+        drive.initialize();
+        launcher.initialize();
+        lighting.initialize();
+        intake.initialize();
 
         // Wire lighting to receive lane color updates from intake
         intake.addLaneColorListener(lighting);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Robot.java
@@ -1,5 +1,6 @@
 package org.firstinspires.ftc.teamcode;
 
+import com.bylazar.configurables.annotations.Configurable;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.Light;
 
@@ -14,7 +15,24 @@ import org.firstinspires.ftc.teamcode.util.Alliance;
 import org.firstinspires.ftc.teamcode.util.RobotState;
 import org.firstinspires.ftc.teamcode.telemetry.TelemetryService;
 
+@Configurable
 public class Robot {
+
+    @Configurable
+    public static class VisionConfig {
+        /**
+         * Enable automatic vision relocalization during TeleOp.
+         *
+         * IMPORTANT: Currently using MegaTag1 (MT1) which is less reliable than MT2.
+         * MT1 provides single-tag poses with 4-8" accuracy and can be noisy/jumpy.
+         *
+         * Recommendation: Keep DISABLED until MegaTag2 (MT2) is fixed.
+         * - MT1 relocalization can introduce more error than odometry drift
+         * - Manual relocalization (A button) is still available when needed
+         * - Once MT2 is working (2-3" accuracy, multi-tag fusion), re-enable this
+         */
+        public static boolean enableAutoRelocalization = false;
+    }
     public final DriveSubsystem drive;
     public final LauncherSubsystem launcher;
     public final IntakeSubsystem intake;
@@ -56,7 +74,8 @@ public class Robot {
     }
 
     public void initializeForTeleOp() {
-        configureInitialization(true, true);
+        // Use configurable flag for vision relocalization (disabled by default with MT1)
+        configureInitialization(true, VisionConfig.enableAutoRelocalization);
     }
 
     private void configureInitialization(boolean enableTeleOpControl, boolean enableVisionRelocalization) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Robot.java
@@ -19,9 +19,9 @@ import org.firstinspires.ftc.teamcode.telemetry.TelemetryService;
 public class Robot {
 
     @Configurable
-    public static class VisionConfig {
+    public static class RelocalizationConfig {
         /**
-         * Enable automatic vision relocalization during TeleOp.
+         * Enable automatic vision relocalization during aiming in TeleOp.
          *
          * IMPORTANT: Currently using MegaTag1 (MT1) which is less reliable than MT2.
          * MT1 provides single-tag poses with 4-8" accuracy and can be noisy/jumpy.
@@ -31,10 +31,10 @@ public class Robot {
          * - Manual relocalization (A button) is still available when needed
          * - Once MT2 is working (2-3" accuracy, multi-tag fusion), re-enable this
          */
-        public boolean enableAutoRelocalization = false;
+        public boolean enableRelocalizationDuringAiming = false;
     }
 
-    public static VisionConfig visionConfig = new VisionConfig();
+    public static RelocalizationConfig relocalizationConfig = new RelocalizationConfig();
 
     public final DriveSubsystem drive;
     public final LauncherSubsystem launcher;
@@ -78,7 +78,7 @@ public class Robot {
 
     public void initializeForTeleOp() {
         // Use configurable flag for vision relocalization (disabled by default with MT1)
-        configureInitialization(true, visionConfig.enableAutoRelocalization);
+        configureInitialization(true, relocalizationConfig.enableRelocalizationDuringAiming);
     }
 
     private void configureInitialization(boolean enableTeleOpControl, boolean enableVisionRelocalization) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/bindings/DriverBindings.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/bindings/DriverBindings.java
@@ -32,7 +32,7 @@ import dev.nextftc.ftc.GamepadEx;
  *
  * Vision Relocalization:
  * - A button: MANUAL vision relocalization (instant, no movement)
- * - Automatic relocalization: DISABLED by default (see Robot.VisionConfig)
+ * - Automatic relocalization: DISABLED by default (see Robot.RelocalizationConfig)
  *   - Currently using MT1 which can be noisy (4-8" accuracy)
  *   - Manual A button relocalization available when needed
  *   - Will re-enable automatic when MT2 is fixed

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/bindings/DriverBindings.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/bindings/DriverBindings.java
@@ -32,10 +32,10 @@ import dev.nextftc.ftc.GamepadEx;
  *
  * Vision Relocalization:
  * - A button: MANUAL vision relocalization (instant, no movement)
- * - Automatic relocalization: DISABLED by default (see DriveSubsystem.VisionRelocalizationConfig)
- *   - Currently using MT1 which can be noisy (4-8" accuracy)
- *   - Manual A button relocalization available when needed
- *   - Will re-enable automatic when MT2 is fixed
+ * - Robot starts with known pose during init (set before match)
+ * - Odometry tracks from initial pose
+ * - Manual relocalization available when drift is noticeable
+ * - PoseFusion runs continuously for diagnostics (not used for control yet)
  */
 public class DriverBindings {
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/bindings/DriverBindings.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/bindings/DriverBindings.java
@@ -22,15 +22,20 @@ import dev.nextftc.ftc.GamepadEx;
  *
  * Drive Commands:
  * - Default: Normal field-centric drive with slow/ramp modes
- * - B button (hold): Geometry-based continuous aim-and-drive (uses pose + incenter)
+ * - B button (hold): Geometry-based continuous aim-and-drive (uses odometry + incenter)
  *
- * Testing Aiming Methods (D-pad):
- * - D-pad Up: Vision-centered continuous tracking (centers AprilTag in camera)
- * - D-pad Down: Fixed-angle continuous tracking (60° blue, 120° red)
+ * Aiming Methods (for testing/comparison):
+ * - B button: Geometry-based (odometry + incenter) - RECOMMENDED for competition
+ * - D-pad Up: Vision-centered continuous tracking (centers AprilTag tx)
+ * - D-pad Down: Fixed-angle continuous tracking (134° blue, 46° red) - RELIABLE from known positions
  * - D-pad Left: Capture-and-aim snap turn (samples then discrete turn)
  *
- * Other:
- * - A button: Vision relocalization (instant, no movement)
+ * Vision Relocalization:
+ * - A button: MANUAL vision relocalization (instant, no movement)
+ * - Automatic relocalization: DISABLED by default (see Robot.VisionConfig)
+ *   - Currently using MT1 which can be noisy (4-8" accuracy)
+ *   - Manual A button relocalization available when needed
+ *   - Will re-enable automatic when MT2 is fixed
  */
 public class DriverBindings {
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/bindings/DriverBindings.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/bindings/DriverBindings.java
@@ -32,7 +32,7 @@ import dev.nextftc.ftc.GamepadEx;
  *
  * Vision Relocalization:
  * - A button: MANUAL vision relocalization (instant, no movement)
- * - Automatic relocalization: DISABLED by default (see Robot.RelocalizationConfig)
+ * - Automatic relocalization: DISABLED by default (see DriveSubsystem.VisionRelocalizationConfig)
  *   - Currently using MT1 which can be noisy (4-8" accuracy)
  *   - Manual A button relocalization available when needed
  *   - Will re-enable automatic when MT2 is fixed

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/DriveSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/DriveSubsystem.java
@@ -96,11 +96,28 @@ public class DriveSubsystem implements Subsystem {
         public double fallbackDtSeconds = 0.02;
     }
 
+    @Configurable
+    public static class VisionRelocalizationConfig {
+        /**
+         * Enable automatic vision relocalization during aiming in TeleOp.
+         *
+         * IMPORTANT: Currently using MegaTag1 (MT1) which is less reliable than MT2.
+         * MT1 provides single-tag poses with 4-8" accuracy and can be noisy/jumpy.
+         *
+         * Recommendation: Keep DISABLED until MegaTag2 (MT2) is fixed.
+         * - MT1 relocalization can introduce more error than odometry drift
+         * - Manual relocalization (A button) is still available when needed
+         * - Once MT2 is working (2-3" accuracy, multi-tag fusion), re-enable this
+         */
+        public boolean enableDuringAiming = false;
+    }
+
     public static TeleOpDriveConfig teleOpDriveConfig = new TeleOpDriveConfig();
     public static AimAssistConfig aimAssistConfig = new AimAssistConfig();
     public static VisionCenteredAimConfig visionCenteredAimConfig = new VisionCenteredAimConfig();
     public static FixedAngleAimConfig fixedAngleAimConfig = new FixedAngleAimConfig();
     public static RampConfig rampConfig = new RampConfig();
+    public static VisionRelocalizationConfig visionRelocalizationConfig = new VisionRelocalizationConfig();
 
     public String visionRelocalizeStatus = "Press A to re-localize";
     public long visionRelocalizeStatusMs = 0L;


### PR DESCRIPTION
With the reversion to MegaTag1 (MT1), automatic vision relocalization
introduces more noise than odometry drift. MT1 provides single-tag poses
with 4-8" accuracy vs MT2's 2-3" multi-tag fusion.

Changes:
- Add Robot.VisionConfig.enableAutoRelocalization flag (default: false)
- Disable automatic relocalization in initializeForTeleOp()
- Manual A button relocalization still available when needed
- Add explanatory comments about MT1 limitations
- Update DriverBindings docs to clarify aiming method recommendations

Recommended aiming strategy with MT1:
- Method 1 (B button): Geometry-based with pure odometry - stable
- Method 3 (D-pad Down): Fixed-angle from known positions - most reliable
- Manual relocalize with A button when drift is noticeable

When MT2 is fixed, set enableAutoRelocalization = true in FTC Dashboard.