### PR TITLE
Organize Launcher configs into separate files

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/launcher/config/LauncherFeederConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/launcher/config/LauncherFeederConfig.java
@@ -1,0 +1,69 @@
+package org.firstinspires.ftc.teamcode.subsystems.launcher.config;
+
+import com.bylazar.configurables.annotations.Configurable;
+
+/**
+ * Feeder (bootkicker) configuration for launcher servos.
+ * Contains base configuration and robot-specific instances.
+ */
+@Configurable
+public class LauncherFeederConfig {
+    public LeftFeederConfig left = new LeftFeederConfig();
+    public CenterFeederConfig center = new CenterFeederConfig();
+    public RightFeederConfig right = new RightFeederConfig();
+
+    @Configurable
+    public static class LeftFeederConfig {
+        public String servoName = "feeder_left";
+        public boolean reversed = false;
+        public double loadPosition = .8;
+        public double firePosition = .61; //toward 0 moves toward fire position
+        public double holdMs = 1000;
+    }
+
+    @Configurable
+    public static class CenterFeederConfig {
+        public String servoName = "feeder_center";
+        public boolean reversed = false;
+        public double loadPosition = .93;
+        public double firePosition = .75; //toward 0 moves toward fire position
+        public double holdMs = 1000;
+    }
+
+    @Configurable
+    public static class RightFeederConfig {
+        public String servoName = "feeder_right";
+        public boolean reversed = false;
+        public double loadPosition = .75;
+        public double firePosition = .56; //toward 0 moves toward fire position
+        public double holdMs = 1000;
+    }
+
+    // Robot-specific instances
+    public static LauncherFeederConfig feederConfig19429 = createFeederConfig19429();
+    public static LauncherFeederConfig feederConfig20245 = createFeederConfig20245();
+
+    /**
+     * Creates feeder configuration for robot 19429.
+     */
+    private static LauncherFeederConfig createFeederConfig19429() {
+        return new LauncherFeederConfig(); // Uses default values
+    }
+
+    /**
+     * Creates feeder configuration for robot 20245.
+     */
+    private static LauncherFeederConfig createFeederConfig20245() {
+        LauncherFeederConfig config = new LauncherFeederConfig();
+        // Apply 20245-specific values
+        config.center.loadPosition = .18;
+        config.center.firePosition = .03;
+
+        config.right.loadPosition = .78;
+        config.right.firePosition = .58;
+
+        config.left.loadPosition = .33;
+        config.left.firePosition = .18;
+        return config;
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/launcher/config/LauncherFlywheelConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/launcher/config/LauncherFlywheelConfig.java
@@ -1,0 +1,127 @@
+package org.firstinspires.ftc.teamcode.subsystems.launcher.config;
+
+import com.bylazar.configurables.annotations.Configurable;
+
+/**
+ * Flywheel configuration for launcher motors.
+ * Contains base configuration and robot-specific instances.
+ */
+@Configurable
+public class LauncherFlywheelConfig {
+
+    public enum FlywheelControlMode {
+        HYBRID,
+        BANG_BANG_HOLD,
+        PURE_BANG_BANG
+    }
+
+    public FlywheelParameters parameters = new FlywheelParameters();
+    public FlywheelModeConfig modeConfig = new FlywheelModeConfig();
+
+    @Configurable
+    public static class FlywheelParameters {
+        /** Encoder ticks per motor revolution (adjust for the selected motor). */
+        public double ticksPerRev = 28;
+        /** Output wheel revolutions per motor revolution. */
+        public double gearRatio = 1.0;
+        /** Acceptable RPM error when considering a lane ready to fire. */
+        public double rpmTolerance = 50;
+    }
+
+    @Configurable
+    public static class FlywheelModeConfig {
+        public FlywheelControlMode mode = FlywheelControlMode.HYBRID;
+        public BangBangConfig bangBang = new BangBangConfig();
+        public HybridPidConfig hybridPid = new HybridPidConfig();
+        public HoldConfig hold = new HoldConfig();
+        public PhaseSwitchConfig phaseSwitch = new PhaseSwitchConfig();
+
+        @Configurable
+        public static class BangBangConfig {
+            public double highPower = 1.0;
+            public double lowPower = 0.2;
+            public double enterBangThresholdRpm = 800;
+            public double exitBangThresholdRpm = 600;
+        }
+
+        @Configurable
+        public static class HybridPidConfig {
+            public double kP = .0065;
+            public double kF = .22; // Why was 6 afraid of 7? Because 7 ate 9!
+            public double maxPower = 1.0;
+        }
+
+        @Configurable
+        public static class HoldConfig {
+            public double baseHoldPower = 0.6;
+            public double rpmPowerGain = 0.00012;
+            public double minHoldPower = 0.2;
+            public double maxHoldPower = 1.0;
+        }
+
+        @Configurable
+        public static class PhaseSwitchConfig {
+            public int bangToHybridConfirmCycles = 1;
+            public int bangToHoldConfirmCycles = 3;
+            public int hybridToBangConfirmCycles = 3;
+            public int holdToBangConfirmCycles = 3;
+        }
+    }
+
+    public LeftFlywheelConfig flywheelLeft = new LeftFlywheelConfig();
+    public CenterFlywheelConfig flywheelCenter = new CenterFlywheelConfig();
+    public RightFlywheelConfig flywheelRight = new RightFlywheelConfig();
+
+    @Configurable
+    public static class LeftFlywheelConfig {
+        public String motorName = "launcher_left";
+        public boolean reversed = true; ///19429 has to be true.
+        public double idleRpm = 1100;
+    }
+
+    @Configurable
+    public static class CenterFlywheelConfig {
+        public String motorName = "launcher_center";
+        public boolean reversed = false;
+        public double idleRpm = 1100;
+    }
+
+    @Configurable
+    public static class RightFlywheelConfig { //actually left
+        public String motorName = "launcher_right";
+        public boolean reversed = true;
+        public double idleRpm = 1100;
+    }
+
+    // Robot-specific instances
+    public static LauncherFlywheelConfig flywheelConfig19429 = createFlywheelConfig19429();
+    public static LauncherFlywheelConfig flywheelConfig20245 = createFlywheelConfig20245();
+
+    /**
+     * Creates flywheel configuration for robot 19429.
+     */
+    private static LauncherFlywheelConfig createFlywheelConfig19429() {
+        LauncherFlywheelConfig config = new LauncherFlywheelConfig();
+        config.parameters.rpmTolerance = 50;  // Tighter tolerance
+        config.modeConfig.hybridPid.kP = 0.008;  // Different PID gain
+        config.flywheelLeft.reversed = true;  // 19429 has left motor reversed
+        config.flywheelLeft.idleRpm = 1500;
+        config.flywheelCenter.idleRpm = 1500;
+        config.flywheelRight.idleRpm = 1500;
+        return config;
+    }
+
+    /**
+     * Creates flywheel configuration for robot 20245.
+     */
+    private static LauncherFlywheelConfig createFlywheelConfig20245() {
+        LauncherFlywheelConfig config = new LauncherFlywheelConfig();
+        config.parameters.rpmTolerance = 50;  // Looser tolerance
+        config.modeConfig.hybridPid.kP = 0.008;
+        config.flywheelLeft.reversed = false;  // 20245 has left motor forward
+        config.flywheelLeft.idleRpm = 1500;
+        config.flywheelCenter.idleRpm = 1500;
+        config.flywheelRight.idleRpm = 1500;
+        return config;
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/launcher/config/LauncherHoodConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/launcher/config/LauncherHoodConfig.java
@@ -1,0 +1,116 @@
+package org.firstinspires.ftc.teamcode.subsystems.launcher.config;
+
+import com.bylazar.configurables.annotations.Configurable;
+
+/**
+ * Hood configuration for launcher angle adjustment.
+ * Contains base configuration and robot-specific instances.
+ */
+@Configurable
+public class LauncherHoodConfig {
+    public double retractedPosition = 1;
+    public double extendedPosition = 0;
+
+    public LeftHoodConfig hoodLeft = new LeftHoodConfig();
+    public CenterHoodConfig hoodCenter = new CenterHoodConfig();
+    public RightHoodConfig hoodRight = new RightHoodConfig();
+
+    @Configurable
+    public static class LeftHoodConfig {
+        public String servoName = "hood_left";
+
+        /**
+         * Hood position for short range shots
+         */
+        public double shortPosition = .3;
+        /**
+         * Hood position for mid range shots
+         */
+        public double midPosition = .05;
+        /**
+         * Hood position for long range shots
+         */
+        public double longPosition = 0;
+    }
+
+    @Configurable
+    public static class CenterHoodConfig {
+        public String servoName = "hood_center";
+        /**
+         * Hood position for short range shots
+         */
+        public double shortPosition = .3;
+        /**
+         * Hood position for mid range shots
+         */
+        public double midPosition = .05;
+        /**
+         * Hood position for long range shots
+         */
+        public double longPosition = 0;
+    }
+
+    @Configurable
+    public static class RightHoodConfig {
+        public String servoName = "hood_right";
+        /**
+         * Hood position for short range shots
+         */
+        public double shortPosition =.3;
+        //TODO consider idle position and weirdness if idle is above the short shot.
+        /**
+         * Hood position for mid range shots
+         */
+        public double midPosition = .05;
+        /**
+         * Hood position for long range shots
+         */
+        public double longPosition = 0;
+    }
+
+    // Robot-specific instances
+    public static LauncherHoodConfig hoodConfig19429 = createHoodConfig19429();
+    public static LauncherHoodConfig hoodConfig20245 = createHoodConfig20245();
+
+    /**
+     * Creates hood configuration for robot 19429.
+     */
+    private static LauncherHoodConfig createHoodConfig19429() {
+        LauncherHoodConfig config = new LauncherHoodConfig();
+        config.hoodRight.midPosition = 0.05;
+        config.hoodRight.longPosition = 0;
+        config.hoodRight.shortPosition = .3;
+
+        config.hoodCenter.midPosition = 0.05;
+        config.hoodCenter.longPosition = 0;
+        config.hoodCenter.shortPosition = .3;
+
+        config.hoodLeft.midPosition = 0.05;
+        config.hoodLeft.longPosition = 0;
+        config.hoodLeft.shortPosition = .3;
+        // Apply 20245-specific values if needed
+        // (currently using default values - customize as needed)
+        return config;
+    }
+
+    /**
+     * Creates hood configuration for robot 20245.
+     */
+    private static LauncherHoodConfig createHoodConfig20245() {
+        LauncherHoodConfig config = new LauncherHoodConfig();
+        config.hoodRight.midPosition = 0.05;
+        config.hoodRight.longPosition = 0;
+        config.hoodRight.shortPosition = .3;
+
+        config.hoodCenter.midPosition = 0.05;
+        config.hoodCenter.longPosition = 0;
+        config.hoodCenter.shortPosition = .3;
+
+        config.hoodLeft.midPosition = 0.05;
+        config.hoodLeft.longPosition = 0;
+        config.hoodLeft.shortPosition = .3;
+        // Apply 20245-specific values if needed
+        // (currently using default values - customize as needed)
+        return config;
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/launcher/config/LauncherReverseIntakeConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/launcher/config/LauncherReverseIntakeConfig.java
@@ -1,0 +1,13 @@
+package org.firstinspires.ftc.teamcode.subsystems.launcher.config;
+
+import com.bylazar.configurables.annotations.Configurable;
+
+/**
+ * Configuration for reverse flywheel intake mode.
+ * Used when loading game pieces from human player station.
+ */
+@Configurable
+public class LauncherReverseIntakeConfig {
+    /** Power level for reverse intake (negative runs motors backward) */
+    public double reversePower = -0.7;
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/launcher/config/LauncherTimingConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/launcher/config/LauncherTimingConfig.java
@@ -1,0 +1,43 @@
+package org.firstinspires.ftc.teamcode.subsystems.launcher.config;
+
+import com.bylazar.configurables.annotations.Configurable;
+
+/**
+ * Timing configuration for launcher operations.
+ * Contains base configuration and robot-specific instances.
+ */
+@Configurable
+public class LauncherTimingConfig {
+    /** Minimum time the wheel should be commanded at launch speed before trusting fallback readiness. */
+    public double minimalSpinUpMs = 500;
+    /** If encoders are unavailable, treat the wheel as ready after this many milliseconds at full power. */
+    public double fallbackReadyMs = 500;
+    /** Time to keep flywheel at launch speed after firing to ensure artifact clears (ms). */
+    public double launchHoldAfterFireMs = 500;
+    /** Servo dwell time to allow the artifact to clear before re-closing (ms). */
+    public double recoveryMs = 350;
+    /** Delay between sequential shots when bursting all three lanes (ms). */
+    public double burstSpacingMs = 120.0;
+
+    // Robot-specific instances
+    public static LauncherTimingConfig timing19429 = createTiming19429();
+    public static LauncherTimingConfig timing20245 = createTiming20245();
+
+    /**
+     * Creates timing configuration for robot 19429.
+     */
+    private static LauncherTimingConfig createTiming19429() {
+        LauncherTimingConfig timing = new LauncherTimingConfig();
+        timing.recoveryMs = 350;  // 19429 uses longer recovery time
+        return timing;
+    }
+
+    /**
+     * Creates timing configuration for robot 20245.
+     */
+    private static LauncherTimingConfig createTiming20245() {
+        LauncherTimingConfig timing = new LauncherTimingConfig();
+        timing.recoveryMs = 150;  // 20245 uses shorter recovery time
+        return timing;
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/launcher/config/LauncherVoltageCompensationConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/launcher/config/LauncherVoltageCompensationConfig.java
@@ -1,0 +1,17 @@
+package org.firstinspires.ftc.teamcode.subsystems.launcher.config;
+
+import com.bylazar.configurables.annotations.Configurable;
+
+/**
+ * Voltage compensation configuration for consistent launcher performance.
+ * Adjusts motor power based on battery voltage to maintain consistent RPM.
+ */
+@Configurable
+public class LauncherVoltageCompensationConfig {
+    /** Enable battery voltage compensation for consistent motor performance */
+    public boolean enabled = true;
+    /** Nominal battery voltage for calibration (typically 12.5V for full charge) */
+    public double nominalVoltage = 12.5;
+    /** Minimum voltage threshold - below this, compensation is clamped for safety */
+    public double minVoltage = 9.0;
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/RobotConfigs.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/RobotConfigs.java
@@ -6,7 +6,10 @@ import com.pedropathing.ftc.localization.constants.PinpointConstants;
 import org.firstinspires.ftc.teamcode.pedroPathing.Constants;
 import org.firstinspires.ftc.teamcode.subsystems.DriveSubsystem;
 import org.firstinspires.ftc.teamcode.subsystems.IntakeSubsystem;
-import org.firstinspires.ftc.teamcode.subsystems.LauncherSubsystem;
+import org.firstinspires.ftc.teamcode.subsystems.launcher.config.LauncherFeederConfig;
+import org.firstinspires.ftc.teamcode.subsystems.launcher.config.LauncherFlywheelConfig;
+import org.firstinspires.ftc.teamcode.subsystems.launcher.config.LauncherHoodConfig;
+import org.firstinspires.ftc.teamcode.subsystems.launcher.config.LauncherTimingConfig;
 
 /**
  * Centralized robot-specific configuration selector.
@@ -19,31 +22,31 @@ public class RobotConfigs {
 
     /**
      * Gets the active FeederConfig for the current robot.
-     * Returns the static instance from LauncherSubsystem so Dashboard edits are applied.
+     * Returns the static instance from LauncherFeederConfig so Dashboard edits are applied.
      * @return FeederConfig19429 or FeederConfig20245 based on robot name
      */
-    public static LauncherSubsystem.FeederConfig getFeederConfig() {
+    public static LauncherFeederConfig getFeederConfig() {
         String robotName = RobotState.getRobotName();
         if ("DECODE_19429".equals(robotName)) {
-            return LauncherSubsystem.feederConfig19429;
+            return LauncherFeederConfig.feederConfig19429;
         } else {
-            // Default to 19429 config if robot name is unknown or is 19429
-            return LauncherSubsystem.feederConfig20245;
+            // Default to 20245 config if robot name is unknown or is 20245
+            return LauncherFeederConfig.feederConfig20245;
         }
     }
 
     /**
      * Gets the active HoodConfig for the current robot.
-     * Returns the static instance from LauncherSubsystem so Dashboard edits are applied.
+     * Returns the static instance from LauncherHoodConfig so Dashboard edits are applied.
      * @return HoodConfig19429 or HoodConfig20245 based on robot name
      */
-    public static LauncherSubsystem.HoodConfig getHoodConfig() {
+    public static LauncherHoodConfig getHoodConfig() {
         String robotName = RobotState.getRobotName();
         if ("DECODE_19429".equals(robotName)) {
-            return LauncherSubsystem.hoodConfig19429;
+            return LauncherHoodConfig.hoodConfig19429;
         } else {
-            // Default to 19429 config if robot name is unknown or is 19429
-            return LauncherSubsystem.hoodConfig20245;
+            // Default to 20245 config if robot name is unknown or is 20245
+            return LauncherHoodConfig.hoodConfig20245;
         }
     }
 
@@ -112,29 +115,29 @@ public class RobotConfigs {
 
     /**
      * Gets the active Timing for the current robot.
-     * Returns the static instance from LauncherSubsystem so Dashboard edits are applied.
+     * Returns the static instance from LauncherTimingConfig so Dashboard edits are applied.
      * @return timing19429 or timing20245 based on robot name
      */
-    public static LauncherSubsystem.Timing getTiming() {
+    public static LauncherTimingConfig getTiming() {
         String robotName = RobotState.getRobotName();
         if ("DECODE_19429".equals(robotName)) {
-            return LauncherSubsystem.timing19429;
+            return LauncherTimingConfig.timing19429;
         } else {
-            return LauncherSubsystem.timing20245;
+            return LauncherTimingConfig.timing20245;
         }
     }
 
     /**
      * Gets the active FlywheelConfig for the current robot.
-     * Returns the static instance from LauncherSubsystem so Dashboard edits are applied.
+     * Returns the static instance from LauncherFlywheelConfig so Dashboard edits are applied.
      * @return flywheelConfig19429 or flywheelConfig20245 based on robot name
      */
-    public static LauncherSubsystem.FlywheelConfig getFlywheelConfig() {
+    public static LauncherFlywheelConfig getFlywheelConfig() {
         String robotName = RobotState.getRobotName();
         if ("DECODE_19429".equals(robotName)) {
-            return LauncherSubsystem.flywheelConfig19429;
+            return LauncherFlywheelConfig.flywheelConfig19429;
         } else {
-            return LauncherSubsystem.flywheelConfig20245;
+            return LauncherFlywheelConfig.flywheelConfig20245;
         }
     }
 


### PR DESCRIPTION
Extracted launcher configuration classes from LauncherSubsystem into separate, focused configuration files under subsystems/launcher/config/:

- LauncherTimingConfig: Shot timing and recovery parameters
- LauncherFlywheelConfig: Flywheel motor control and PID settings
- LauncherFeederConfig: Feeder servo positions and timing
- LauncherHoodConfig: Hood angle positions for shot ranges
- LauncherVoltageCompensationConfig: Battery voltage compensation
- LauncherReverseIntakeConfig: Reverse intake power settings

Each config file contains:
- Base configuration class with default values
- Robot-specific instances (19429 and 20245)
- Factory methods for robot-specific customization

Benefits:
- Easier to view and compare robot-specific configurations
- Cleaner separation between subsystem logic and configuration
- Each config type in its own file for easier navigation
- All configs remain @Configurable for FTC Dashboard tuning

Updated LauncherSubsystem to import and use the new config classes. Updated RobotConfigs to reference the new config class locations.

Before issuing a pull request, please see the contributing page.
